### PR TITLE
Perf logging

### DIFF
--- a/kafka-slurp.py
+++ b/kafka-slurp.py
@@ -122,7 +122,7 @@ def get_next_offset(partition_dir):
 @log_duration()
 def compress(fname, suffix):
     # xz without the flag `-k` will delete the original file
-    subprocess.run(["xz", "-3", "--suffix", suffix, fname], capture_output=True, check=True)
+    subprocess.run(["xz", "-3", "-T", "1", "--suffix", suffix, fname], capture_output=True, check=True)
 
 
 @log_duration()


### PR DESCRIPTION
This adds a perf-logging decorator, and extracts a few things from `run(..)` into separate functions, which are then decorated with the perf logging.

The result is output such as
`{"timestamp": "2020-03-17T10:30:49.699404+01:00", "app": "kafka-slurp", "sli": "compress", "durationSec": 0.710507}`
for download of each segment, compression, moving the files into place, and for measuring the time taking to figure out what the next segment is.


This _also_ forces `xz` to only use a single thread. It should probably be configurable, but `xz` using however many threads it wants is probably not helping performance, when multiple compressions are likely to run simultaneously.